### PR TITLE
Fix module resolution error

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,7 +1,7 @@
-import { analyzeVideos } from 'analysis.js';
-import { runTranscriptionIfEnabled } from 'asr.js';
-import { exportCompilation } from 'export.js';
-import { formatSeconds } from 'utils.js';
+import { analyzeVideos } from './analysis.js';
+import { runTranscriptionIfEnabled } from './asr.js';
+import { exportCompilation } from './export.js';
+import { formatSeconds } from './utils.js';
 
 const state = {
   videoFiles: [],


### PR DESCRIPTION
Fix `TypeError` for module resolution by updating bare module specifier imports to relative paths in `src/app.js`.

---
<a href="https://cursor.com/background-agent?bcId=bc-518e1917-525e-4e72-98ff-81803cd43271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-518e1917-525e-4e72-98ff-81803cd43271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

